### PR TITLE
Update LocalMachineStateStorage.java

### DIFF
--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/LocalMachineStateStorage.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/LocalMachineStateStorage.java
@@ -162,7 +162,8 @@ public class LocalMachineStateStorage implements MachineStateStorage {
         if (!stateDirectory.exists()) {
             return new File[0];
         }
-        return stateDirectory.listFiles(((dir, name) -> name.startsWith(namespace)));
+        String encodedNamespace = BaseEncoding.base64().encode(namespace.getBytes(Charsets.UTF_8));
+        return stateDirectory.listFiles(((dir, name) -> name.startsWith(encodedNamespace)));
     }
     
     @Override


### PR DESCRIPTION
Fix getStateFilesOf method:
the state file is really named with prefix encoding namespace.

Fixes #671.

Changes proposed in this pull request:
-
-
-
